### PR TITLE
chore: auto-merge Dependabot patch/minor updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,37 @@
+name: Dependabot auto-merge (patch/minor)
+
+on:
+  pull_request_target:
+    types: [opened, reopened, synchronize, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve patch/minor updates
+        if: |
+          ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+              steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        uses: hmarr/auto-approve-action@v4
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge (squash)
+        if: |
+          ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
+              steps.metadata.outputs.update-type == 'version-update:semver-minor' }}
+        uses: peter-evans/enable-pull-request-automerge@v3
+        with:
+          pull-request-number: ${{ github.event.pull_request.number }}
+          merge-method: squash


### PR DESCRIPTION
This adds a minimal workflow to auto-approve and enable auto-merge for Dependabot PRs when the update type is semver patch or minor.

Key points:
- Trigger: pull_request_target
- Restriction: Only for PRs opened by dependabot[bot]
- Uses dependabot/fetch-metadata@v2 to detect update type
- Auto-approve via hmarr/auto-approve-action@v4
- Enable auto-merge via peter-evans/enable-pull-request-automerge@v3 with squash

Repo settings required:
- Settings → General → Pull Requests → Enable "Allow auto-merge"
- If branch protection requires approvals, ensure actions/bots can approve Dependabot PRs or set required approvals to 0 for Dependabot.
